### PR TITLE
Set the default for telemetry to internal_use true

### DIFF
--- a/config/full/full.yaml
+++ b/config/full/full.yaml
@@ -20,6 +20,9 @@ ootb_supply_chain_basic:
   cluster_builder: default
   service_account: default
 
+tap_telemetry:
+   installed_for_vmware_internal_use: "true"
+
 contour:
   envoy:
     service:


### PR DESCRIPTION
Since this repo is most used for development, indicate that telemetry is for internal_use. 